### PR TITLE
Actualización del formulario de nuevas recetas

### DIFF
--- a/TP_Final_Grupo1/src/main/resources/templates/nueva_receta.html
+++ b/TP_Final_Grupo1/src/main/resources/templates/nueva_receta.html
@@ -36,8 +36,8 @@
 			  <div class="btn-group mb-3" role="group" aria-label="Basic checkbox toggle button group" th:each="ingrediente : ${Ingredientes}">
 				  <input th:value="${ingrediente.id}" th:field="*{listaIngredientes}" type="checkbox"  th:id="${'recetaIngredientes'}+${ingrediente.id}" autocomplete="off">
 				  <label th:text="${ingrediente.nombre}" class="btn btn-outline-primary" th:for="${'recetaIngredientes'}+${ingrediente.id}"></label>
-				  <div class="text-danger" th:if="${#fields.hasErrors('listaIngredientes')}" th:errors="*{listaIngredientes}"></div>
 			  </div>
+			  <div class="text-danger" th:if="${#fields.hasErrors('listaIngredientes')}" th:errors="*{listaIngredientes}"></div>
 			  <!-- <div class="mb-3" id="desplegableIngredientes">
 		      	<label for="recetaIngredientes" class="form-label">Ingredientes</label>
 			    <select id="recetaIngredientes" class="form-select" th:field="*{listaIngredientes}">


### PR DESCRIPTION
-Se cambia de posición el "div" que muestra los errores del atributo "listaIngredientes" para que no se vea afectado por el bucle.